### PR TITLE
empirical: add hrs-scf skill (SCF Fed survey + RAND HRS panel) (#5)

### DIFF
--- a/extensions/empirical/utils/hrs_scf_utils.py
+++ b/extensions/empirical/utils/hrs_scf_utils.py
@@ -1,0 +1,562 @@
+"""HRS / SCF household-survey panels for retirement and wealth research.
+
+Two free household-survey sources, zero overlap with WRDS/CRSP:
+
+  * SCF — Survey of Consumer Finances (Federal Reserve, triennial 1989-2022).
+    Cross-sectional household balance sheets with IRA/401(k)/DB-pension
+    wealth, net worth, and income by age/cohort. Public-use files download
+    with NO key from federalreserve.gov. Each survey carries FIVE multiply-
+    imputed implicates (multiple imputation for missing/disclosure-edited
+    values) — handling them correctly is the #1 silent SCF error; see the
+    weight note below and scf_combine_implicates().
+
+  * HRS — Health & Retirement Study (RAND HRS Longitudinal File). The gold-
+    standard individual-level panel for retirement timing, labour-force
+    transitions, and Social Security claiming (biennial since 1992). (HRS
+    *the survey* also covers rollover/pension-disposition events, but those
+    fields are NOT in the curated Longitudinal-File stems this helper ships
+    — see hrs_retirement_panel's SCOPE LIMIT.) REGISTRATION-WALLED:
+    you must create an HRS account, accept the data-use agreement, and bulk-
+    download the RAND HRS file once. The helper reads a user-placed extract
+    from data/hrs_scf/hrs/ — manual placement is the ONLY supported path: no
+    automated/authenticated download is attempted, because the HRS site
+    (hrsdata.isr.umich.edu) sits behind CDN bot protection that 403s many
+    datacenter/cloud IPs even with credentials. It NEVER fails silently:
+    with no file it raises a RuntimeError that states the exact registration
+    step and where to drop the file (documented limit, not a silent failure
+    — same posture as ssa.gov in bls_census_utils).
+
+Usage:
+    from utils.hrs_scf_utils import (
+        scf_summary, scf_full, scf_replicate_weights,
+        scf_combine_implicates, scf_retirement_by_cohort,
+        load_rand_hrs, hrs_retirement_panel,
+    )
+
+HRS scope limit (documented, not silent): the shipped RAND-stem set covers
+retirement TIMING and stocks (labour-force status, self-reported
+retirement, IRA/pension assets). It does NOT include IRA-ROLLOVER /
+pension-disposition event variables — those live in the HRS pension and
+exit modules / RAND HRS detailed pension files, not the curated
+Longitudinal-File stems. For rollover analysis pass your own stems via
+hrs_retirement_panel(stems=...) against a RAND file that carries them.
+
+Caching: every fetch is memoised to data/hrs_scf/<tag>_<hash>.parquet
+(parquet preferred; transparent CSV fallback if pyarrow is unavailable).
+Public-use SCF files for a given year are immutable once released, so cache
+hits are safe; pass refresh=True to re-pull.
+
+SCF WEIGHT SCALING (the silent error this skill is built to prevent):
+  In the SCF Summary Extract `wgt`, and the full-set `x42001`-derived
+  weight, are constructed so that summing the weight over ALL FIVE
+  stacked implicates returns the U.S. household population (~131.3M in
+  2022). Summing over a SINGLE implicate returns ~1/5 of the population.
+  Therefore:
+    - Weighted means/medians/totals over the full stacked file (all 5
+      implicates) using `wgt` are correct as-is. Do NOT additionally
+      divide by 5.
+    - Do NOT compute a population TOTAL on one implicate with `wgt` and
+      expect the right number (you get 1/5).
+    - For correct standard errors use Rubin's rules: compute the point
+      estimate within each implicate, then combine with the between-
+      implicate variance (scf_combine_implicates() does the point-estimate
+      side; replicate-weight SEs need scf_replicate_weights()).
+"""
+import hashlib
+import io
+import json
+import os
+import urllib.error
+import urllib.request
+import zipfile
+
+import pandas as pd
+
+# NOTE: this module intentionally does NOT import/call dotenv. It reads no
+# API keys or credentials of any kind — SCF is keyless and HRS is manual-
+# placement-only (no authenticated download is attempted). Keeping dotenv
+# out makes that contract obvious at the imports.
+
+_DATA_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "data", "hrs_scf")
+)
+_HRS_DIR = os.path.join(_DATA_DIR, "hrs")
+_SCF_BASE = "https://www.federalreserve.gov/econres/files"
+_BROWSER_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+
+# SCF is triennial; these are the released public-use survey years.
+SCF_YEARS = [1989, 1992, 1995, 1998, 2001, 2004,
+             2007, 2010, 2013, 2016, 2019, 2022]
+
+# SCF Summary-Extract age class (verified vs rscfp2022). Use with by="agecl".
+SCF_AGECL = {1: "<35", 2: "35-44", 3: "45-54",
+             4: "55-64", 5: "65-74", 6: "75+"}
+
+# SCF Summary-Extract retirement-account variables (verified present in
+# rscfp2022). These are the headline IRA/401(k)/pension-balance fields the
+# issue-#5 use case is about. Definitions follow the SCF codebook; consult it
+# for exact construction. `h`-prefixed twins (e.g. hretqliq) are 0/1 "has any"
+# flags. retqliq is THE quasi-liquid retirement-balance variable. NB:
+# irakh and thrift are COMPONENTS of retqliq — never sum them with retqliq
+# (double-counts); pick retqliq for a total, or irakh/thrift to decompose.
+SCF_RETIREMENT_VARS = {
+    "retqliq":   "quasi-liquid retirement: IRA/Keogh + account-type "
+                 "(401k/403b/thrift/SRA) + lump-sum-expected pensions",
+    "irakh":     "IRA and Keogh account balances",
+    "thrift":    "account-type pension balances (401k/403b/thrift/SRA), "
+                 "current + past jobs",
+    "reteq":     "total retirement equity (retqliq + account-type pensions "
+                 "currently in pay status / annuitized equity)",
+    "penacctwd": "withdrawals taken from pension accounts",
+    "ssretinc":  "Social Security + retirement income (annual flow)",
+    "annuit":    "value of annuities (not retirement-account specific)",
+    "futpen":    "future (not-yet-received) pension benefits",
+    "currpen":   "pension income currently being received",
+    "anypen":    "has any pension coverage (0/1)",
+}
+
+# RAND HRS wave -> survey year (biennial; wave 1 = 1992). The 2020 (V2)
+# Longitudinal File runs through wave 15. Use to label hrs_retirement_panel.
+HRS_WAVE_YEAR = {w: 1990 + 2 * w for w in range(1, 16)}  # w1=1992 ... w15=2020
+
+# Curated RAND HRS variable stems for the retirement panel. RAND HRS naming
+# is stable across versions: respondent-level vars are r{wave}{stem},
+# household-level h{wave}{stem}, time-invariant ra{stem}. Override via the
+# `stems` argument of hrs_retirement_panel().
+_HRS_R_STEMS = {
+    "agey_e": "age_years",       # age in years, end of interview
+    "lbrf": "labor_force",       # labour-force status (1-7 RAND recode)
+    "sayret": "self_rpt_ret",    # self-reported retirement (0/1/2/3)
+    "work": "working",           # working for pay (0/1)
+    "retemp": "ret_then_work",   # retired then returned to work
+    "iearn": "earnings",         # individual earnings
+    "ssret": "ss_retire_inc",    # Social Security retirement income
+}
+_HRS_H_STEMS = {
+    "aira": "ira_assets",        # household IRA/Keogh assets
+    "atotb": "wealth_total",     # total household wealth (incl. 2nd home)
+    "itot": "income_total",      # total household income
+}
+_HRS_RA_STEMS = {
+    "gender": "gender", "byear": "birth_year", "racem": "race",
+    "educ": "education", "hispan": "hispanic",
+}
+
+
+# ─────────────────────────── caching ────────────────────────────
+def _cache_path(tag, payload):
+    os.makedirs(_DATA_DIR, exist_ok=True)
+    h = hashlib.md5(
+        (tag + "|" + json.dumps(payload, sort_keys=True, default=str)).encode()
+    ).hexdigest()[:16]
+    return os.path.join(_DATA_DIR, f"{tag}_{h}")
+
+
+def _cache_load(base):
+    if os.path.exists(base + ".parquet"):
+        try:
+            return pd.read_parquet(base + ".parquet")
+        except Exception:
+            pass
+    if os.path.exists(base + ".csv"):
+        return pd.read_csv(base + ".csv")
+    return None
+
+
+def _cache_save(base, df):
+    try:
+        df.to_parquet(base + ".parquet", index=False)
+    except Exception:
+        df.to_csv(base + ".csv", index=False)
+    return df
+
+
+def _download(url, timeout=300):
+    """GET bytes with a browser UA. Raises a readable RuntimeError on HTTP
+    errors (the federalreserve.gov host serves files cleanly; a 404 here
+    almost always means a non-existent survey year or a typo'd file stem)."""
+    req = urllib.request.Request(url, headers={"User-Agent": _BROWSER_UA})
+    try:
+        return urllib.request.urlopen(req, timeout=timeout).read()
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(
+            f"HTTP {e.code} fetching {url}. For SCF this usually means the "
+            f"survey year is not a triennial public-use year "
+            f"(valid: {SCF_YEARS})."
+        ) from None
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"Network error fetching {url}: {e.reason}") from None
+
+
+def _read_only_dta_in_zip(raw):
+    """Read the single .dta member of a downloaded SCF zip. The inner file
+    name varies by year/product (rscfp2022.dta, p22i6.dta, p22_rw1.dta, ...),
+    so select it generically rather than hardcoding."""
+    zf = zipfile.ZipFile(io.BytesIO(raw))
+    dtas = [n for n in zf.namelist() if n.lower().endswith(".dta")]
+    if not dtas:
+        raise RuntimeError(
+            f"No .dta member in SCF zip (members: {zf.namelist()})."
+        )
+    if len(dtas) > 1:
+        print(f"  [hrs_scf] SCF zip has multiple .dta members {dtas}; "
+              f"reading the first ({dtas[0]}).")
+    with zf.open(dtas[0]) as fh:
+        return pd.read_stata(io.BytesIO(fh.read()), convert_categoricals=False)
+
+
+# ─────────────────────────── SCF ────────────────────────────────
+def scf_summary(year, refresh=False):
+    """SCF Summary Extract Public Data (analysis-ready derived variables).
+
+    This is the file most household-finance papers use: ~350 constructed
+    variables — net worth, income, asset/debt categories, and the key
+    retirement aggregates RETQLIQ (quasi-liquid retirement: IRAs + thrift/
+    401(k)-type accounts), and the survey weight `wgt`.
+
+    Args:
+        year: an SCF triennial year (see SCF_YEARS). NO key required.
+        refresh: bypass the on-disk cache.
+
+    Returns:
+        DataFrame with all 5 implicates STACKED (rows = households x 5).
+        Key columns: `yy1` (household id), `y1` (implicate id = yy1*10+m),
+        `wgt` (population weight — see the module-level WEIGHT SCALING note:
+        sum over ALL 5 implicates ~= population; do not also divide by 5),
+        `age`, `agecl`, `networth`, `income`, `retqliq`, ...
+    """
+    base = _cache_path("scf_summary", {"year": int(year)})
+    if not refresh:
+        hit = _cache_load(base)
+        if hit is not None:
+            return hit
+    raw = _download(f"{_SCF_BASE}/scfp{int(year)}s.zip")
+    return _cache_save(base, _read_only_dta_in_zip(raw))
+
+
+def scf_full(year, replicates=False, refresh=False):
+    """SCF Full Public Data Set (every survey variable, Stata).
+
+    The full file is large (~250-290 MB uncompressed) and uses the raw
+    X-coded variable names (e.g. X42001 = raw weight). Prefer scf_summary()
+    unless you need a variable not in the summary extract.
+
+    Args:
+        year: an SCF triennial year (see SCF_YEARS). NO key required.
+        replicates: if True, also fetch the bootstrap replicate-weight file
+            and return it merged on the household id (`yy1`). The full file
+            then carries the wt1b1..wt1b999 replicate-weight columns for
+            replication-based standard errors.
+        refresh: bypass the on-disk cache.
+
+    Returns:
+        DataFrame with all 5 implicates stacked. Household id `yy1`,
+        implicate id `y1`.
+    """
+    base = _cache_path("scf_full", {"year": int(year), "rw": bool(replicates)})
+    if not refresh:
+        hit = _cache_load(base)
+        if hit is not None:
+            return hit
+    raw = _download(f"{_SCF_BASE}/scf{int(year)}s.zip")
+    df = _read_only_dta_in_zip(raw)
+    if replicates:
+        rw = scf_replicate_weights(year, refresh=refresh)
+        key = "yy1" if ("yy1" in df.columns and "yy1" in rw.columns) else "y1"
+        df = df.merge(rw, on=key, how="left", suffixes=("", "_rw"))
+    return _cache_save(base, df)
+
+
+def scf_replicate_weights(year, refresh=False):
+    """SCF bootstrap replicate-weight file (one row per household).
+
+    999 replicate weights (wt1b1..wt1b999) keyed by household id `yy1`/`y1`.
+    Use these for design-correct standard errors (the SCF is a dual-frame
+    stratified sample; naive SEs understate uncertainty).
+
+    Args:
+        year: an SCF triennial year (see SCF_YEARS). NO key required.
+        refresh: bypass the on-disk cache.
+    """
+    base = _cache_path("scf_rw", {"year": int(year)})
+    if not refresh:
+        hit = _cache_load(base)
+        if hit is not None:
+            return hit
+    raw = _download(f"{_SCF_BASE}/scf{int(year)}rw1s.zip")
+    return _cache_save(base, _read_only_dta_in_zip(raw))
+
+
+def scf_combine_implicates(df, value_cols, weight_col="wgt", by=None,
+                           stat="mean"):
+    """Multiple-imputation point estimates across the 5 SCF implicates.
+
+    Computes the weighted statistic WITHIN each implicate, then averages
+    the five implicate estimates (Rubin's rule for the point estimate).
+    This is the correct way to summarise the stacked file — a single
+    weighted statistic over the pooled 22,975-ish rows is NOT wrong for a
+    mean/share (the weight scaling makes it numerically equal) but IS wrong
+    for any nonlinear statistic (median, quantiles, inequality measures)
+    because those do not commute with stacking.
+
+    Args:
+        df: a stacked SCF DataFrame (from scf_summary/scf_full).
+        value_cols: column name or list of columns to summarise.
+        weight_col: population weight (default 'wgt').
+        by: optional grouping column(s) (e.g. 'agecl').
+        stat: 'mean' or 'median'.
+
+    Returns:
+        DataFrame of the implicate-averaged statistic. The implicate id is
+        derived as `y1 % 10` (SCF convention y1 = yy1*10 + implicate).
+    """
+    vcols = [value_cols] if isinstance(value_cols, str) else list(value_cols)
+    g = df.copy()
+    g["_imp"] = g["y1"].astype("int64") % 10
+    grp = (["_imp"] + ([by] if isinstance(by, str) else list(by))) if by \
+        else ["_imp"]
+
+    def _wstat(block):
+        w = block[weight_col].to_numpy(dtype=float)
+        out = {}
+        for c in vcols:
+            x = block[c].to_numpy(dtype=float)
+            if stat == "mean":
+                out[c] = (x * w).sum() / w.sum()
+            elif stat == "median":
+                order = x.argsort()
+                x, cw = x[order], w[order].cumsum()
+                out[c] = x[(cw >= 0.5 * w.sum()).argmax()]
+            else:
+                raise ValueError("stat must be 'mean' or 'median'")
+        return pd.Series(out)
+
+    # Select only the columns _wstat touches before grouping. This avoids
+    # needing include_groups=False (a kwarg that only exists in pandas
+    # >= 2.2): weight_col and vcols are never grouping keys, so the result
+    # is correct on every pandas version. (A DeprecationWarning about
+    # operating on grouping columns still fires on pandas 2.2 — harmless.)
+    sub = g[grp + vcols + [weight_col]]
+    per_imp = (sub.groupby(grp).apply(_wstat).reset_index())
+    avg_by = [c for c in per_imp.columns
+              if c not in vcols and c != "_imp"]
+    return (per_imp.groupby(avg_by)[vcols].mean().reset_index()
+            if avg_by else per_imp[vcols].mean().to_frame().T)
+
+
+def scf_retirement_by_cohort(year, vars=None, by="agecl", stat="median",
+                             refresh=False):
+    """Headline issue-#5 convenience: IRA/401(k)/pension balances by cohort.
+
+    Pulls scf_summary(year) and returns the MI-correct (within-implicate
+    then averaged) retirement-account balances by age class. This is the
+    one-call path for "retirement wealth by cohort"; it is exactly
+    scf_combine_implicates restricted to the verified retirement-variable
+    set with the age-class label attached.
+
+    Args:
+        year: an SCF triennial year (see SCF_YEARS). NO key required.
+        vars: subset of SCF_RETIREMENT_VARS keys (default: all present in
+            the file — retqliq/irakh/thrift/reteq/...).
+        by: grouping column (default 'agecl'; the returned frame adds an
+            'age_band' label column from SCF_AGECL when by == 'agecl').
+        stat: 'median' (default) or 'mean'. Medians/quantiles MUST be
+            implicate-combined (they do not commute with stacking) — this
+            helper does that for you.
+        refresh: bypass the on-disk cache.
+
+    Returns:
+        DataFrame [<by>, (age_band), <retirement vars>], one row per cohort.
+    """
+    df = scf_summary(year, refresh=refresh)
+    keys = list(vars) if vars else list(SCF_RETIREMENT_VARS)
+    present = [c for c in keys if c in df.columns]
+    missing = [c for c in keys if c not in df.columns]
+    if missing:
+        print(f"  [scf_retirement_by_cohort] not in SCF {year} summary "
+              f"extract, skipped: {missing}")
+    if not present:
+        raise RuntimeError(
+            f"No retirement variables present in SCF {year} "
+            f"(looked for {keys})."
+        )
+    out = scf_combine_implicates(df, present, by=by, stat=stat)
+    if by == "agecl":
+        out.insert(1, "age_band", out["agecl"].map(SCF_AGECL))
+    return out
+
+
+# ─────────────────────────── HRS ────────────────────────────────
+def _find_local_hrs(version):
+    """Find a user-placed RAND HRS extract under data/hrs_scf/hrs/.
+    Accepts .dta / .sav / .sas7bdat / .parquet / .csv. A filename
+    containing the version letter (e.g. 'v2', 'Q') is preferred."""
+    if not os.path.isdir(_HRS_DIR):
+        return None
+    exts = (".parquet", ".dta", ".sav", ".sas7bdat", ".csv")
+    cands = [os.path.join(_HRS_DIR, f) for f in sorted(os.listdir(_HRS_DIR))
+             if f.lower().endswith(exts)]
+    if not cands:
+        return None
+    tagged = [c for c in cands
+              if str(version).lower() in os.path.basename(c).lower()]
+    return (tagged or cands)[0]
+
+
+def _read_any(path):
+    p = path.lower()
+    if p.endswith(".parquet"):
+        return pd.read_parquet(path)
+    if p.endswith(".csv"):
+        return pd.read_csv(path)
+    if p.endswith(".dta"):
+        return pd.read_stata(path, convert_categoricals=False)
+    if p.endswith(".sav"):
+        return pd.read_spss(path)          # needs pyreadstat
+    if p.endswith(".sas7bdat"):
+        return pd.read_sas(path)
+    raise RuntimeError(f"Unsupported RAND HRS file type: {path}")
+
+
+def load_rand_hrs(version="Q", path=None, refresh=False):
+    """Load the RAND HRS Longitudinal File (the standard analysis-ready
+    HRS panel: wide, one row per person, wave-suffixed variables).
+
+    Access model (HRS is registration-walled — this is by design, not a
+    helper limitation):
+      1. Cached parquet  -> returned immediately.
+      2. Explicit `path=` -> read that file, cache it.
+      3. A file the user placed under data/hrs_scf/hrs/ -> read, cache.
+      4. Otherwise -> RuntimeError stating the exact registration step.
+
+    To enable HRS:
+      * Register at https://hrsdata.isr.umich.edu (free), request the RAND
+        HRS Longitudinal File, accept the data-use agreement.
+      * Download the Stata/SPSS/SAS bundle, unzip it, and drop the data
+        file (e.g. randhrs1992_2020v2.dta) into:
+            data/hrs_scf/hrs/
+      * Re-run; the helper will read and cache it.
+
+    The HRS host (hrsdata.isr.umich.edu) is behind CDN bot protection that
+    403s many datacenter/cloud IPs, so automated download is unreliable
+    even with credentials — the manual-placement path is the supported one.
+    This is a documented limit (same posture as ssa.gov in
+    bls_census_utils), not a silent failure.
+
+    Args:
+        version: RAND HRS version tag (letter or 'vN'); used to pick among
+            multiple local files and to tag the cache. Default 'Q'.
+        path: explicit path to a downloaded RAND HRS data file.
+        refresh: bypass the on-disk cache.
+    """
+    base = _cache_path("rand_hrs", {"version": str(version)})
+    if not refresh:
+        hit = _cache_load(base)
+        if hit is not None:
+            return hit
+    src = path or _find_local_hrs(version)
+    if src and os.path.isfile(src):
+        return _cache_save(base, _read_any(src))
+    raise RuntimeError(
+        "RAND HRS file not found. HRS is registration-walled and cannot be "
+        "fetched without an approved account. To enable it:\n"
+        "  1. Register (free) at https://hrsdata.isr.umich.edu and request "
+        "the RAND HRS Longitudinal File; accept the data-use agreement.\n"
+        "  2. Download + unzip the Stata/SPSS/SAS bundle.\n"
+        f"  3. Place the data file (e.g. randhrs1992_2020v2.dta) in:\n"
+        f"       {_HRS_DIR}\n"
+        "  4. Re-run load_rand_hrs(). (The HRS host 403s many cloud IPs, so "
+        "automated download is unreliable even with credentials — manual "
+        "placement is the supported path. Documented limit, not a silent "
+        "failure.)"
+    )
+
+
+def hrs_retirement_panel(version="Q", stems=None, path=None, refresh=False):
+    """Reshape the wide RAND HRS file to a long person x wave panel of
+    retirement-relevant variables (age, labour-force status, self-reported
+    retirement, return-to-work, IRA assets, total wealth, SS income, ...).
+
+    RAND HRS stores wave-varying variables as r{wave}{stem} (respondent)
+    and h{wave}{stem} (household). This detects the waves present, melts the
+    curated stem set to long, and keeps time-invariant ra{stem} attributes.
+    Stems with no matching column are skipped with a warning (RAND drops or
+    renames a few stems across versions) — never a silent wrong column.
+
+    SCOPE LIMIT (documented): the default stems cover retirement TIMING and
+    stocks, NOT IRA-rollover / pension-disposition events (those are in the
+    HRS pension/exit modules, not the Longitudinal-File curated stems). Add
+    them via stems= against a RAND file that carries them.
+
+    Args:
+        version, path, refresh: passed to load_rand_hrs().
+        stems: optional dict overriding the default stem -> output-name map.
+            Keys 'r','h','ra' map to respondent/household/invariant dicts;
+            pass any subset.
+
+    Returns:
+        Long DataFrame [hhidpn, wave, year, <renamed retirement vars>,
+        <invariant attributes>], sorted by hhidpn, wave. `year` is the
+        survey year from HRS_WAVE_YEAR (wave 1 = 1992, biennial).
+    """
+    wide = load_rand_hrs(version=version, path=path, refresh=refresh)
+    cols = {c.lower(): c for c in wide.columns}
+    rmap = (stems or {}).get("r", _HRS_R_STEMS)
+    hmap = (stems or {}).get("h", _HRS_H_STEMS)
+    ramap = (stems or {}).get("ra", _HRS_RA_STEMS)
+
+    id_col = cols.get("hhidpn") or cols.get("hhid")
+    if id_col is None:
+        raise RuntimeError(
+            "No hhidpn/hhid id column in the RAND HRS file — is this the "
+            "RAND HRS Longitudinal File (not a raw HRS core file)?"
+        )
+
+    # Discover waves present from any r{w}{stem} column.
+    waves = set()
+    for w in range(1, 20):
+        for pre, mp in (("r", rmap), ("h", hmap)):
+            for st in mp:
+                if f"{pre}{w}{st}".lower() in cols:
+                    waves.add(w)
+    if not waves:
+        raise RuntimeError(
+            "No wave-suffixed RAND HRS variables found (expected e.g. "
+            "r14lbrf, h14atotb). The stem map may not match this version; "
+            "pass stems=... to override."
+        )
+
+    missing, frames = set(), []
+    for w in sorted(waves):
+        rec = {id_col: wide[id_col], "wave": w}
+        for pre, mp in (("r", rmap), ("h", hmap)):
+            for st, out in mp.items():
+                src = cols.get(f"{pre}{w}{st}".lower())
+                if src:
+                    rec[out] = wide[src]
+                else:
+                    missing.add(f"{pre}*{st}")
+        frames.append(pd.DataFrame(rec))
+    long = pd.concat(frames, ignore_index=True)
+    long.insert(2, "year", long["wave"].map(HRS_WAVE_YEAR))
+
+    inv_cols = {}
+    for st, out in ramap.items():
+        src = cols.get(f"ra{st}".lower())
+        if src:
+            inv_cols[out] = src
+        else:
+            missing.add(f"ra{st}")
+    if inv_cols:
+        inv = wide[[id_col] + list(inv_cols.values())].rename(
+            columns={v: k for k, v in inv_cols.items()})
+        long = long.merge(inv, on=id_col, how="left")
+
+    if missing:
+        print(f"  [hrs_retirement_panel] stems not in this RAND HRS "
+              f"version, skipped: {sorted(missing)}")
+    return (long.rename(columns={id_col: "hhidpn"})
+            .sort_values(["hhidpn", "wave"]).reset_index(drop=True))

--- a/templates/skill_bodies/empirical/hrs-scf.md
+++ b/templates/skill_bodies/empirical/hrs-scf.md
@@ -1,0 +1,205 @@
+## Source
+- **SCF — Survey of Consumer Finances** (Federal Reserve, triennial
+  1989–2022). Cross-sectional household balance sheets: net worth, income,
+  IRA/401(k)/DB-pension wealth by age and cohort. Public-use files at
+  predictable URLs under `https://www.federalreserve.gov/econres/files/`,
+  **no key**. Every survey carries **five multiply-imputed implicates**.
+- **HRS — Health & Retirement Study** (RAND HRS Longitudinal File). The
+  gold-standard individual-level panel for retirement timing, return-to-
+  work, and Social Security claiming (biennial since 1992; rollover events
+  need the detailed-pension stems — see the HRS scope limit below).
+  **Registration-walled**: free account + data-use agreement +
+  bulk download at https://hrsdata.isr.umich.edu. The helper reads a
+  user-placed extract; it never fails silently.
+- **PSID** is out of scope here (large/complex — issue #5 marks it lower
+  priority); use FRED/SCF/HRS for the retirement-and-wealth questions PSID
+  would otherwise serve.
+- Zero overlap with WRDS/CRSP; both free. Use for retirement timing,
+  IRA/401(k) balances by cohort, wealth distribution, and household-finance
+  micro-validation (e.g. pairing HRS individual retirement timing with
+  macro Bartik shifters from the `bls-census` or
+  `form-5500` skills).
+
+## Setup
+
+```python
+from utils.hrs_scf_utils import (
+    scf_summary, scf_full, scf_replicate_weights,
+    scf_combine_implicates, scf_retirement_by_cohort,
+    load_rand_hrs, hrs_retirement_panel,
+)
+```
+
+No keys. Every fetch is memoised to `data/hrs_scf/*.parquet` (CSV fallback
+if pyarrow is missing). Public-use SCF years are immutable once released —
+cache hits are safe; pass `refresh=True` only to re-pull.
+
+## How to use
+
+### SCF Summary Extract (no key) — start here
+
+```python
+df = scf_summary(2022)        # analysis-ready derived variables
+# rows = households x 5 implicates; key cols:
+#   yy1 (household id), y1 (implicate id = yy1*10+m), wgt (pop weight),
+#   age, agecl, networth, income, retqliq (IRA + thrift/401k-type),
+#   reteq, irakh, ...
+```
+
+`scf_summary(year)` is the file most household-finance papers use (~350
+constructed variables). Valid years: 1989, 1992, 1995, 1998, 2001, 2004,
+2007, 2010, 2013, 2016, 2019, 2022.
+
+**Retirement-account variables** (the issue-#5 headline; verified present
+in the 2022 summary extract — definitions follow the SCF codebook).
+`irakh` and `thrift` are **components of `retqliq`** — use `retqliq` for a
+total, or the components to decompose; never sum them together:
+
+| Variable | What |
+|----------|------|
+| `retqliq` | Quasi-liquid retirement: IRA/Keogh + account-type (401k/403b/thrift/SRA) + lump-sum-expected pensions. **The headline retirement-balance field.** |
+| `irakh` | IRA + Keogh balances (**a component of `retqliq`**) |
+| `thrift` | Account-type pension balances (401k/403b/thrift/SRA), current + past jobs (**a component of `retqliq`**) |
+| `reteq` | Total retirement equity (`retqliq` + annuitized / in-pay-status account pensions) |
+| `penacctwd` | Withdrawals taken from pension accounts |
+| `ssretinc` | Social Security + retirement income (annual flow) |
+| `futpen` / `currpen` | Future (not-yet-received) / currently-received pension benefits |
+| `anypen` | Has any pension coverage (0/1) |
+| `annuit` | Annuity value (not retirement-account specific) |
+
+**Age class** `agecl` (the grouping the cohort helpers use): `1`=<35,
+`2`=35–44, `3`=45–54, `4`=55–64, `5`=65–74, `6`=75+. Other categoricals:
+`edcl` 1–4 (no-HS / HS / some-college / college), `racecl4` 1–4
+(white / black / hispanic / other), `married` 1/2, `lf` 0/1.
+
+### IRA/401(k) balances by cohort (one call)
+
+```python
+ret = scf_retirement_by_cohort(2022)            # MI-correct, by age class
+# columns: agecl, age_band, retqliq, irakh, thrift, reteq, ...
+ret = scf_retirement_by_cohort(2022, vars=["retqliq", "irakh"],
+                               stat="mean")
+```
+
+This is the headline use case — it pulls `scf_summary`, restricts to the
+verified retirement-variable set, computes the implicate-combined statistic
+by `agecl`, and attaches the readable `age_band` label. Use it instead of
+hand-rolling `scf_combine_implicates` for retirement balances.
+
+### The #1 silent SCF error: implicates and weight scaling
+
+The SCF is multiply imputed — **five implicates** per household, stacked.
+The weight `wgt` is constructed so that **summing it over all five
+implicates returns the U.S. household population** (~131.3M in 2022).
+Summing `wgt` over a *single* implicate returns ~1/5 of the population.
+
+- A weighted **mean or share** over the full stacked file with `wgt` is
+  numerically correct as-is — do **not** also divide by 5, and do **not**
+  compute it on one implicate.
+- A weighted **median / quantile / inequality measure** over the pooled
+  stack is **wrong** (these don't commute with stacking). Compute the
+  statistic within each implicate and average — use
+  `scf_combine_implicates`.
+
+```python
+# MI-correct point estimates (computes within each implicate, then averages)
+med = scf_combine_implicates(df, ["networth", "retqliq"],
+                             by="agecl", stat="median")
+mean_nw = scf_combine_implicates(df, "networth", stat="mean")
+```
+
+For design-correct **standard errors** the point estimate is not enough —
+combine the implicate spread (Rubin's between-imputation variance) with the
+SCF bootstrap replicate weights:
+
+```python
+rw  = scf_replicate_weights(2022)              # wt1b1..wt1b999 by yy1
+full = scf_full(2022, replicates=True)         # full file + replicate cols
+```
+
+### SCF Full Public Data Set
+
+```python
+full = scf_full(2022)                  # every survey variable (X-coded)
+full = scf_full(2022, replicates=True) # merged with replicate weights on yy1
+```
+
+Large (~250–290 MB uncompressed) and raw-coded (e.g. `X42001` = raw
+weight). Prefer `scf_summary` unless you need a variable the extract omits.
+
+### HRS — RAND HRS Longitudinal File (registration required)
+
+```python
+panel = hrs_retirement_panel(version="v2")   # long person x wave panel
+wide  = load_rand_hrs(version="v2")          # raw wide RAND HRS file
+```
+
+**HRS is registration-walled — this is by design, not a tool limitation.**
+To enable it:
+
+1. Register (free) at https://hrsdata.isr.umich.edu, request the **RAND
+   HRS Longitudinal File**, accept the data-use agreement.
+2. Download + unzip the Stata/SPSS/SAS bundle.
+3. Drop the data file (e.g. `randhrs1992_2020v2.dta`) into
+   **`data/hrs_scf/hrs/`**.
+4. Re-run — the helper reads, caches, and reshapes it.
+
+With no file and no placement, `load_rand_hrs` raises a `RuntimeError`
+spelling out these exact steps. **Documented limit:** the HRS host
+(`hrsdata.isr.umich.edu`) sits behind CDN bot protection that 403s many
+datacenter/cloud IPs even with credentials, so automated download is
+unreliable — manual placement is the supported path (same posture as
+`ssa.gov` in the `bls-census` skill). This is never a silent failure.
+
+`hrs_retirement_panel()` melts the wide file (RAND stores wave-varying
+variables as `r{wave}{stem}` / `h{wave}{stem}`) into a long
+`[hhidpn, wave, year, age_years, labor_force, self_rpt_ret, working,
+ira_assets, wealth_total, ...]` panel, keeping time-invariant `ra{stem}`
+attributes (gender, birth_year, education). `year` is the survey year
+(**wave→year: wave 1 = 1992, biennial; wave 15 = 2020** for the V2 file).
+Stems absent in your RAND version are **skipped with a printed warning**,
+never silently mapped to the wrong column. Override with
+`stems={"r": {...}, ...}`.
+
+**Scope limit (documented, not silent):** the shipped stems cover
+retirement **timing and stocks** (labour-force status, self-reported
+retirement, IRA/pension assets). They do **not** include IRA-**rollover**
+/ pension-disposition event variables — those fields are in the HRS
+pension and exit modules (and the RAND HRS *detailed pension* files),
+**not** the Longitudinal-File curated stems. For rollover analysis,
+supply your own `stems=` against a
+RAND file that carries them; do not claim rollover results from the
+default panel.
+
+## Standard operations
+
+- **Retirement-wealth by cohort (SCF):** `scf_retirement_by_cohort(2022)`
+  for the MI-correct IRA/401(k)/pension decomposition across age classes;
+  pair with `form-5500` plan-level rollovers and `bls-census` cohort LFPR
+  shifters. (Use `form-5500` for the rollover-flow side — SCF/HRS give the
+  balance and timing side.)
+- **Individual retirement timing (HRS):** `hrs_retirement_panel` →
+  hazard of `labor_force`/`self_rpt_ret` transition by age, merged to a
+  macro Bartik shifter for the retirement-channel design.
+- **Wealth distribution / inequality:** SCF only, and **must** use
+  `scf_combine_implicates` (medians and shares of top wealth do not
+  commute with implicate stacking) plus replicate-weight SEs.
+
+## Rules
+- **SCF is multiply imputed.** State the implicate handling explicitly.
+  Means/shares over the stacked file with `wgt` are correct as-is;
+  medians/quantiles/inequality require `scf_combine_implicates` (within-
+  implicate then averaged). Never divide `wgt` by 5; never compute a
+  population total on one implicate.
+- **Report SCF standard errors with replicate weights** (`scf_full(year,
+  replicates=True)` / `scf_replicate_weights`) plus the between-implicate
+  variance — naive SEs understate uncertainty for this dual-frame
+  stratified sample.
+- **HRS access is registration-walled, by design.** Document in methods
+  that the RAND HRS file was obtained under the HRS data-use agreement and
+  placed in `data/hrs_scf/hrs/`. Do not claim HRS results without the file
+  — the helper raises, it does not fabricate.
+- **State your sample.** SCF survey year(s) and product (summary extract
+  vs full set); RAND HRS version and waves; weight and implicate handling.
+- **Cache aggressively.** Released SCF public-use years are immutable;
+  rely on `data/hrs_scf/*.parquet`, pass `refresh=True` only to re-pull.

--- a/templates/skill_metadata/empirical_skills.json
+++ b/templates/skill_metadata/empirical_skills.json
@@ -53,6 +53,15 @@
       "allowed-tools": "Bash, Read, Write, WebFetch"
     }
   },
+  "hrs-scf": {
+    "name": "hrs-scf",
+    "description": "Household-survey panels for retirement, wealth, and household balance sheets. SCF (Survey of Consumer Finances, Federal Reserve, triennial 1989–2022) downloads with NO key — Summary Extract and Full Public Data Set with 5 multiply-imputed implicates. HRS (Health & Retirement Study / RAND HRS Longitudinal File) is registration-walled: the helper reads a user-placed extract from data/hrs_scf/hrs/ (the realistic workflow — bulk download after accepting the data-use agreement) and documents the registration step; it never fails silently. Use for retirement timing, IRA/401(k) balances by cohort, wealth distribution, and household-finance micro-validation (e.g. pairing HRS individual retirement timing with macro Bartik shifters). Rollover/pension-disposition events need HRS detailed-pension stems supplied via stems= (documented, not the default panel).",
+    "claude": {
+      "user-invocable": true,
+      "argument-hint": "[SCF year, RAND HRS variable, or description]",
+      "allowed-tools": "Bash, Read, Write"
+    }
+  },
   "ken-french": {
     "name": "ken-french",
     "description": "Download factor returns, portfolio returns, and breakpoints from the Ken French Data Library. Use for asset pricing calibration, computing alphas, and building test assets.",

--- a/test_scripts/test_hrs_scf.py
+++ b/test_scripts/test_hrs_scf.py
@@ -1,0 +1,112 @@
+"""Test hrs-scf skill — SCF (no key) + HRS registration-walled (issue #5).
+
+Acceptance:
+  * Pull one SCF year with NO key, verify implicate structure and the
+    weight-scaling invariant (sum of wgt over all 5 implicates ~= US
+    household population).
+  * MI-combine (within-implicate then average) gives plausible 2022 net
+    worth (median ~$190k, mean ~$1.06M per the Fed 2022 bulletin).
+  * Verify the HRS download path: with no file and no credentials,
+    load_rand_hrs / hrs_retirement_panel must raise the instructive
+    registration RuntimeError (SKIP, not FAIL — HRS is registration-walled
+    by design). If a user-placed RAND HRS file exists, exercise the reshape.
+
+Run from project root:
+    PYTHONPATH=code python3 test_scripts/test_hrs_scf.py
+"""
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# === Test 1: scf_summary — one SCF year, NO key ===
+print("=== Test 1: scf_summary(2022) — no key ===")
+from utils.hrs_scf_utils import scf_summary
+
+df = scf_summary(2022)
+assert not df.empty, "SCF summary returned no rows"
+assert {"yy1", "y1", "wgt", "networth", "income", "retqliq"} <= set(df.columns), \
+    f"missing expected SCF columns: {list(df.columns)[:20]}"
+n_imp = (df["y1"].astype("int64") % 10).nunique()
+assert n_imp == 5, f"expected 5 implicates, got {n_imp}"
+print(f"  {len(df)} rows = {df['yy1'].nunique()} households x {n_imp} implicates")
+
+# === Test 2: the SCF weight-scaling invariant ===
+print("\n=== Test 2: sum(wgt) over all 5 implicates ~= US households ===")
+tot = df["wgt"].sum()
+assert 1.2e8 < tot < 1.45e8, \
+    f"sum(wgt) over 5 implicates = {tot:,.0f}, not ~1.31e8 (US households)"
+one_imp = df[(df["y1"].astype("int64") % 10) == 1]["wgt"].sum()
+assert abs(one_imp - tot / 5) / tot < 0.01, \
+    "single-implicate wgt sum should be ~1/5 of the all-implicate sum"
+print(f"  all 5: {tot:,.0f}   one implicate: {one_imp:,.0f} (~1/5) — invariant holds")
+
+# === Test 3: MI-combined net worth (within-implicate then averaged) ===
+print("\n=== Test 3: scf_combine_implicates — 2022 net worth ===")
+from utils.hrs_scf_utils import scf_combine_implicates
+
+med = scf_combine_implicates(df, "networth", stat="median")["networth"].iloc[0]
+mean = scf_combine_implicates(df, "networth", stat="mean")["networth"].iloc[0]
+assert 1.5e5 < med < 2.4e5, f"2022 median net worth implausible: {med:,.0f}"
+assert 8e5 < mean < 1.3e6, f"2022 mean net worth implausible: {mean:,.0f}"
+by = scf_combine_implicates(df, "retqliq", by="agecl", stat="median")
+assert by["agecl"].nunique() >= 5 and by["retqliq"].max() > 0, \
+    "retqliq-by-agecl looks wrong"
+print(f"  median net worth ${med:,.0f}, mean ${mean:,.0f}; "
+      f"retqliq by {by['agecl'].nunique()} age classes OK")
+
+# === Test 3b: cache round-trip ===
+print("\n=== Test 3b: SCF parquet cache round-trip ===")
+assert scf_summary(2022).equals(df), "cache round-trip changed the DataFrame"
+print("  identical on re-read")
+
+# === Test 3c: scf_retirement_by_cohort — headline issue-#5 convenience ===
+print("\n=== Test 3c: scf_retirement_by_cohort(2022) ===")
+from utils.hrs_scf_utils import scf_retirement_by_cohort, SCF_AGECL
+
+rc = scf_retirement_by_cohort(2022, stat="mean")  # mean has the lifecycle hump
+assert {"agecl", "age_band", "retqliq", "irakh"} <= set(rc.columns), \
+    f"missing expected retirement-cohort columns: {list(rc.columns)}"
+assert rc["agecl"].nunique() == 6, f"expected 6 age classes, got {rc['agecl'].tolist()}"
+assert set(rc["age_band"]) == set(SCF_AGECL.values()), \
+    f"age_band labels wrong: {rc['age_band'].tolist()}"
+rc = rc.sort_values("agecl")
+# Mean retqliq is hump-shaped over the lifecycle: peaks at pre-/at-retirement
+# (agecl 4-5), and the youngest cohort holds far less than the peak.
+peak = rc.loc[rc["retqliq"].idxmax(), "agecl"]
+assert peak in (4, 5), f"mean retqliq peaks at age class {peak}, expected 4-5"
+assert rc.iloc[0]["retqliq"] < rc["retqliq"].max(), \
+    "youngest cohort should hold less retirement wealth than the peak"
+print(f"  6 cohorts; mean retqliq peaks at age band "
+      f"{rc.loc[rc['retqliq'].idxmax(), 'age_band']} "
+      f"(${rc['retqliq'].max():,.0f}), youngest "
+      f"${rc.iloc[0]['retqliq']:,.0f}")
+
+# === Test 4: HRS download path — registration-walled by design ===
+print("\n=== Test 4: load_rand_hrs / hrs_retirement_panel ===")
+from utils.hrs_scf_utils import load_rand_hrs, hrs_retirement_panel
+
+try:
+    panel = hrs_retirement_panel()
+    # Only reachable if the user placed a RAND HRS file in data/hrs_scf/hrs/.
+    assert {"hhidpn", "wave"} <= set(panel.columns), \
+        f"HRS panel missing id/wave: {list(panel.columns)}"
+    assert panel["wave"].nunique() >= 1, "HRS panel has no waves"
+    print(f"  user RAND HRS file found: {len(panel)} person-wave rows, "
+          f"{panel['wave'].nunique()} waves — reshape OK")
+except RuntimeError as e:
+    msg = str(e)
+    assert "hrsdata.isr.umich.edu" in msg and "data/hrs_scf/hrs" in msg, \
+        f"HRS error not instructive enough: {msg[:200]}"
+    # load_rand_hrs raises the same instructive error directly.
+    try:
+        load_rand_hrs()
+        print("  UNEXPECTED: load_rand_hrs succeeded with no file")
+        raise SystemExit(1)
+    except RuntimeError as e2:
+        assert "registration" in str(e2).lower(), f"wrong error: {e2}"
+    print("  SKIP (registration-walled by design): helper raised the exact "
+          "registration + manual-placement instructions, no silent failure.")
+
+print("\nALL TESTS PASSED")


### PR DESCRIPTION
Closes #5.

Adds the `hrs-scf` empirical skill: household-survey panels for retirement, IRA/401(k) balances by cohort, and wealth distribution.

## SCF (keyless)
- `scf_summary` / `scf_full` / `scf_replicate_weights` — verified live URL patterns at federalreserve.gov.
- `scf_combine_implicates` — Rubin within-implicate-then-average point estimates.
- `scf_retirement_by_cohort` — headline issue-#5 convenience: MI-correct IRA/401(k)/pension decomposition by age class.
- Encodes the #1 silent SCF error in helper+body+test: `wgt` sums to the US household population over **all five** stacked implicates (single-implicate sum ≈ 1/5), so pooled means/shares are correct as-is but medians/quantiles must be implicate-combined.
- Documented: verified retirement-variable table (with the `irakh`/`thrift` ⊂ `retqliq` no-double-count caveat), `agecl`/`edcl`/`racecl` legends.

## HRS (registration-walled by design)
- `load_rand_hrs` / `hrs_retirement_panel` read a user-placed RAND HRS extract from `data/hrs_scf/hrs/`; raise an instructive `RuntimeError` (registration step + placement path + datacenter-IP 403 documented limit) when absent — no automated/credential download attempted (same posture as `ssa.gov` in `bls_census_utils`).
- Rollover/pension-disposition events honestly documented as **not** in the shipped RAND stems (they live in HRS detailed-pension/exit modules), with the `stems=` override path — not silently implied-covered.
- `hrs_retirement_panel` emits a `year` column from the wave→year map (w1=1992 … w15=2020).

## Verification
- Live SCF 2022 pull: median net worth ~\$192k, mean ~\$1.06M, mean `retqliq` lifecycle hump \$310k at 65–74 — all match the Fed 2022 bulletin.
- HRS reshape verified on a synthetic RAND-shaped file; both fail-loud paths exercised.
- `test_scripts/test_hrs_scf.py` passes (SCF hard-required no-key; HRS SKIPs when no file).
- Four rounds of Sonnet review to convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)