### PR TITLE
empirical: implement bank→holding-company rollup for call-reports (#33)

### DIFF
--- a/extensions/empirical/utils/call_reports_utils.py
+++ b/extensions/empirical/utils/call_reports_utils.py
@@ -34,6 +34,7 @@ Usage:
     from utils.call_reports_utils import (
         call_report, y9c, bank_panel,
         fdic_financials, fdic_institutions, nic_link,
+        bank_to_holder, nic_relationships, nic_attributes,
         list_call_periods, parse_quarter, RC_COMMON_VARS,
     )
 
@@ -44,6 +45,8 @@ Usage:
     pan  = bank_panel('2022Q1', '2023Q4',              # robust FDIC panel
                       vars=['ASSET', 'DEP', 'NETINC'])
     xwalk = nic_link(852218)                           # RSSD <-> CERT <-> name
+    hold = bank_to_holder(852218)                      # bank RSSD -> top holder
+    rel  = nic_relationships()                         # full ownership tree
 
 --------------------------------------------------------------------------
 THE ID LINKING NIGHTMARE (read before merging anything)
@@ -61,14 +64,15 @@ There is NO single bank identifier. The four you will meet:
     so CERT <-> RSSD is a lookup, never an algorithm.
   * SNL/CIQ key, RSSD9001 vs RSSD9999 (the as-of-date RSSD), and the
     "lead bank" vs "top holder" distinction — a BHC's RSSD is NOT its
-    lead bank's RSSD. To roll banks up to their holder you need the NIC
-    relationships table (`nic_link` documents the bulk path).
+    lead bank's RSSD. To roll banks up to their holder use
+    `bank_to_holder()` (the no-key FDIC high-holder path); for the full
+    multi-level ownership tree use `nic_relationships()`/`nic_attributes()`.
 
 Rules of thumb:
   * Never assume RSSD == CERT. They are unrelated integers.
   * Bank-level analysis: key on RSSD (IDRSSD). Holding-company analysis:
     key on the BHC's RSSD9001 from Y-9C. To consolidate banks to holders
-    use NIC relationships, not a name match.
+    use `bank_to_holder()` (or the NIC relationships tree), not a name match.
   * The FDIC API is the cheapest reliable RSSD<->CERT crosswalk.
 """
 import io
@@ -733,8 +737,12 @@ def fdic_financials(quarter, certs=None, fields=None):
         "filters": flt, "fields": ",".join(core), "limit": 1000,
     })
     df = pd.DataFrame(rows)
+    # NAMEHCR (regulatory high-holder NAME) is text like NAME; coercing it
+    # to numeric would silently NaN it out (it rides along when
+    # bank_to_holder/bank_panel request the high-holder fields).
+    text_cols = ("NAME", "STALP", "REPDTE", "NAMEHCR")
     for c in df.columns:
-        if c not in ("NAME", "STALP", "REPDTE"):
+        if c not in text_cols:
             df[c] = pd.to_numeric(df[c], errors="coerce")
     return df
 
@@ -742,8 +750,15 @@ def fdic_financials(quarter, certs=None, fields=None):
 def fdic_institutions(certs=None, rssdids=None, active_only=True):
     """FDIC institution directory — the CERT <-> FED_RSSD crosswalk.
 
-    Returns CERT, NAME, FED_RSSD, CITY, STALP, ACTIVE, etc. Either filter
-    by `certs`, by `rssdids` (FED_RSSD), or pull all (active) institutions.
+    Returns CERT, NAME, FED_RSSD, RSSDHCR, NAMEHCR, CITY, STALP, ACTIVE,
+    etc. Either filter by `certs`, by `rssdids` (FED_RSSD), or pull all
+    (active) institutions.
+
+    `RSSDHCR` / `NAMEHCR` are the RSSD and name of the bank's **Regulatory
+    High Holder** — the top of its holding-company chain, sourced by the
+    FDIC from NIC. This is the no-key, non-walled path used by
+    `bank_to_holder()` to roll banks up to their holder (current snapshot;
+    for point-in-time use `bank_to_holder(..., asof=...)`).
 
     NOTE: if both `certs` and `rssdids` are given the filter is AND
     (intersection) — a row must match a cert AND an rssd. To resolve two
@@ -758,12 +773,17 @@ def fdic_institutions(certs=None, rssdids=None, active_only=True):
         parts.append("(" + " OR ".join(f"FED_RSSD:{int(r)}" for r in rssdids) + ")")
     flt = " AND ".join(parts) if parts else ""
     params = {
-        "fields": "CERT,NAME,FED_RSSD,CITY,STALP,ACTIVE,BKCLASS,ESTYMD",
+        "fields": "CERT,NAME,FED_RSSD,RSSDHCR,NAMEHCR,CITY,STALP,ACTIVE,"
+                  "BKCLASS,ESTYMD",
         "limit": 1000,
     }
     if flt:
         params["filters"] = flt
-    return pd.DataFrame(_fdic_paged("institutions", params))
+    df = pd.DataFrame(_fdic_paged("institutions", params))
+    for c in ("CERT", "FED_RSSD", "RSSDHCR"):
+        if c in df.columns:
+            df[c] = pd.to_numeric(df[c], errors="coerce").astype("Int64")
+    return df
 
 
 def nic_link(rssdid):
@@ -772,22 +792,422 @@ def nic_link(rssdid):
     Practical RSSD <-> CERT crosswalk via the FDIC institutions API
     (reliable, no key). Returns a one-row DataFrame (or empty if the RSSD
     is a holding company / non-FDIC entity — those have an RSSD but no
-    CERT).
+    CERT). The returned row also carries RSSDHCR / NAMEHCR (the bank's
+    regulatory high holder).
 
-    True NIC ownership *hierarchy* (parent/child, lead bank vs top holder)
-    is NOT a name match: download the NIC bulk relationships/attributes
-    CSVs from https://www.ffiec.gov/npw/FinancialReport/DataDownload
-    (CSV_RELATIONSHIPS, CSV_ATTRIBUTES) and join on ID_RSSD. That bulk
-    file is the only correct way to roll banks up to their holding company.
+    To roll a bank up to its holding company use ``bank_to_holder()`` (the
+    no-key FDIC path, sourced from NIC) — NOT a name match. For the full
+    multi-level ownership tree (intermediate parents, equity percentages,
+    as-of edges) use ``nic_relationships()`` / ``nic_attributes()``.
     """
     inst = fdic_institutions(rssdids=[int(rssdid)], active_only=False)
     return inst
 
 
+# ── bank → holding-company rollup ──
+
+def _as_rssd_list(rssdids):
+    """Normalize a scalar or iterable of RSSD ids to a list of plain ints.
+
+    Raises a clear ValueError on NA/None/NaN inputs rather than the opaque
+    int(NAType) TypeError — a caller passing a panel column with missing
+    ids should be told to drop them (the output mapping is total, so a
+    silent drop would break the one-row-per-input guarantee)."""
+    raw = (list(rssdids)
+           if isinstance(rssdids, (list, tuple, set, pd.Series, pd.Index))
+           else [rssdids])
+    if any(x is None or (isinstance(x, float) and pd.isna(x)) or x is pd.NA
+           for x in raw):
+        raise ValueError(
+            "rssdids contains NA/None values; drop them before calling "
+            "bank_to_holder (e.g. panel['IDRSSD'].dropna()).")
+    return [int(x) for x in raw]
+
+
+def bank_to_holder(rssdids, asof=None, source="fdic"):
+    """Map bank RSSD(s) to their top regulatory-high-holder RSSD.
+
+    The correct, no-name-match way to roll bank-level Call Reports up to
+    the holding-company level. ``source='fdic'`` (default) reads the
+    Regulatory High Holder (RSSDHCR/NAMEHCR) the FDIC carries (sourced from
+    NIC) — no key, not behind the NIC Akamai wall:
+
+      * ``asof=None`` — current snapshot, via the FDIC ``/institutions``
+        directory (one call for all ids).
+      * ``asof='2020Q4'`` (any parse_quarter spec) — point-in-time, via the
+        FDIC ``/financials`` endpoint, which carries RSSDHCR per REPDTE.
+
+    ``source='nic'`` instead walks the controlling-parent edges of a
+    user-placed NIC relationships file (``nic_relationships()``) as of
+    ``asof`` (default today) — this is the only path that also gives the
+    *intermediate* tree; it needs the manually downloaded bulk file.
+
+    FBO caveat: RSSDHCR is the top of the **domestic** regulatory chain.
+    For US subsidiaries of foreign banking organizations it stops at the
+    US intermediate holding company (IHC), NOT the foreign ultimate parent
+    (e.g. Santander Bank NA rolls up to Santander Holdings USA, not Banco
+    Santander S.A.). This is a NIC definition, not a retrieval gap; walk
+    ``nic_relationships()`` above the IHC if you need the foreign parent.
+    The ``asof`` output column is ``YYYY-MM-DD`` (point-in-time/NIC) or
+    None (current FDIC snapshot).
+
+    Args:
+        rssdids: a bank RSSD (IDRSSD) int, or an iterable of them.
+        asof: None (current) or a quarter spec for point-in-time.
+        source: 'fdic' (default, robust) or 'nic' (multi-level, manual file).
+
+    Returns: DataFrame, one row per input rssd, columns
+        ``bank_rssd, holder_rssd, holder_name, is_independent, asof,
+        source`` (plus ``bank_name`` for source='fdic'). A bank that is its
+        own top holder (no higher holder) has ``holder_rssd == bank_rssd``
+        and ``is_independent=True``; an unresolved id (not FDIC-insured /
+        absent that quarter) has ``<NA>`` holder fields. The mapping is
+        total: every input id yields exactly one row, in input order.
+    """
+    ids = _as_rssd_list(rssdids)
+    if source == "nic":
+        return _bank_to_holder_nic(ids, asof)
+    if source != "fdic":
+        raise ValueError(f"source must be 'fdic' or 'nic', got {source!r}")
+
+    # A single FED_RSSD can match several FDIC institution records — the
+    # bank's RSSD persists across CERT reassignments (mergers/renames). The
+    # holder RSSD is identical across them, but only the ACTIVE row carries
+    # the current high-holder NAME, and (for asof) only the CERT that filed
+    # that quarter has a financials row. So: prefer the ACTIVE record for
+    # identity, and keep ALL CERTs per RSSD for the point-in-time match.
+    inst = fdic_institutions(rssdids=ids, active_only=False)
+
+    def _is_active(row):
+        return pd.to_numeric(row.get("ACTIVE"), errors="coerce") == 1
+
+    best = {}              # rssd -> preferred (active) institution row
+    rssd_certs = {}        # rssd -> [all historical certs]
+    if not inst.empty and "FED_RSSD" in inst.columns:
+        for _, r in inst.iterrows():
+            fr = r.get("FED_RSSD")
+            if pd.isna(fr):
+                continue
+            fr = int(fr)
+            if fr not in best or (_is_active(r) and not _is_active(best[fr])):
+                best[fr] = r
+            ct = r.get("CERT")
+            if pd.notna(ct):
+                rssd_certs.setdefault(fr, []).append(int(ct))
+
+    if asof is None:
+        rows = []
+        for rid in ids:
+            r = best.get(rid)
+            rows.append(_holder_row(
+                rid, source="fdic", asof=None, found=(r is not None),
+                bank_name=(None if r is None else r.get("NAME")),
+                hcr=(None if r is None else r.get("RSSDHCR")),
+                hcr_name=(None if r is None else r.get("NAMEHCR")),
+            ))
+        return pd.DataFrame(rows)
+
+    # point-in-time: financials carries RSSDHCR per REPDTE, keyed by CERT.
+    # Query every historical CERT, then match each RSSD to whichever of its
+    # CERTs actually filed that quarter.
+    _, _, pe, _ = parse_quarter(asof)
+    all_certs = sorted({c for cs in rssd_certs.values() for c in cs})
+    fin_by_cert = {}
+    if all_certs:
+        fin = fdic_financials(
+            asof, certs=all_certs,
+            fields=["CERT", "REPDTE", "RSSDHCR", "NAMEHCR"])
+        if not fin.empty and "CERT" in fin.columns:
+            for _, r in fin.iterrows():
+                ct = r.get("CERT")
+                if pd.notna(ct):
+                    fin_by_cert[int(ct)] = r
+    rows = []
+    for rid in ids:
+        r = next((fin_by_cert[c] for c in rssd_certs.get(rid, [])
+                  if c in fin_by_cert), None)
+        bn = best.get(rid)
+        rows.append(_holder_row(
+            rid, source="fdic", asof=f"{pe:%Y-%m-%d}", found=(r is not None),
+            bank_name=(None if bn is None else bn.get("NAME")),
+            hcr=(None if r is None else r.get("RSSDHCR")),
+            hcr_name=(None if r is None else r.get("NAMEHCR")),
+        ))
+    return pd.DataFrame(rows)
+
+
+def _holder_row(bank_rssd, source, asof, found, bank_name, hcr, hcr_name):
+    """Assemble one bank_to_holder output row.
+
+    `found` is whether the authoritative holder-source row (FDIC
+    institutions row for asof=None, or the financials row at the requested
+    REPDTE) was located. Not-found -> unresolved (<NA> holder). Found with
+    RSSDHCR absent/0/self -> the bank is its own top holder (independent).
+    """
+    if not found:
+        holder, holder_name, indep = pd.NA, pd.NA, pd.NA
+    else:
+        hcr_num = pd.to_numeric(hcr, errors="coerce")
+        hcr_int = int(hcr_num) if pd.notna(hcr_num) else None
+        if hcr_int in (None, 0) or hcr_int == bank_rssd:   # no higher holder
+            holder, holder_name, indep = bank_rssd, (hcr_name or bank_name), True
+        else:
+            holder, holder_name, indep = hcr_int, (hcr_name or pd.NA), False
+    row = {
+        "bank_rssd": bank_rssd,
+        "holder_rssd": holder,
+        "holder_name": holder_name,
+        "is_independent": indep,
+        "asof": asof,
+        "source": source,
+    }
+    if source == "fdic":
+        row["bank_name"] = bank_name if bank_name is not None else pd.NA
+    return row
+
+
+# ── NIC bulk relationships / attributes (full ownership tree) ──
+#
+# The NIC Financial Data Download (NIC_DATADOWNLOAD_URL) serves the bulk
+# CSV_RELATIONSHIPS / CSV_ATTRIBUTES / CSV_TRANSFORMATIONS bundles, but the
+# whole npw host is behind Akamai bot protection that 403s datacenter/cloud
+# IPs on every path (verified for the static-data dir and the predictable
+# ZIP names alike) — the same wall that forces y9c() 2021Q2+ onto a
+# user-placed file. nic_relationships()/nic_attributes() therefore attempt a
+# best-effort fetch and, on the expected 403, fail loud with the manual
+# download path, then read a user-placed file. For the common bank->top-
+# holder rollup you usually do NOT need these — bank_to_holder() (FDIC) is
+# the no-download path; the bulk file is for the multi-level tree, equity
+# percentages, and historical as-of edges.
+
+NIC_BULK = {
+    # kind -> (fetch filename on the SPA, regex matching a user-placed file)
+    "relationships": ("CSV_RELATIONSHIPS.ZIP", r"RELATIONSHIPS"),
+    "attributes_active": ("CSV_ATTRIBUTES_ACTIVE.ZIP", r"ATTRIBUTES.*ACTIVE"),
+    "attributes_closed": ("CSV_ATTRIBUTES_CLOSED.ZIP", r"ATTRIBUTES.*CLOSED"),
+    "attributes_branches": ("CSV_ATTRIBUTES_BRANCHES.ZIP",
+                            r"ATTRIBUTES.*BRANCH"),
+    "transformations": ("CSV_TRANSFORMATIONS.ZIP", r"TRANSFORMATIONS"),
+}
+
+_NIC_REL_KEYS = ("ID_RSSD_PARENT", "ID_RSSD_OFFSPRING")
+_NIC_ATTR_KEY = "ID_RSSD"
+
+
+def _nic_wall_message(kind, fname):
+    return (
+        f"NIC bulk '{kind}' file not found and could not be fetched. The "
+        f"NIC Financial Data Download ({NIC_DATADOWNLOAD_URL}) is behind "
+        "Akamai bot protection that 403s server/datacenter IPs, so it "
+        "cannot be pulled programmatically (same wall as y9c 2021Q2+). "
+        "Open that page in a browser, choose the relevant download "
+        f"(CSV format), and place the downloaded file (e.g. {fname} or its "
+        f"extracted .CSV) anywhere under {DATA_DIR}/ — the name just has to "
+        "contain the table name. This is a one-time manual step; "
+        "bank_to_holder() (FDIC) needs no download for the top-holder "
+        "rollup."
+    )
+
+
+def _nic_discover(kind):
+    """Find a user-placed NIC bulk file for `kind` anywhere under DATA_DIR
+    (recursively; zip or csv, case-insensitive, with or without a date
+    prefix) — matching the 'place it anywhere under data/call_reports/'
+    instruction in the wall message."""
+    import glob
+    _fname, pat = NIC_BULK[kind]
+    rx = re.compile(pat, re.I)
+    hits = []
+    for p in glob.glob(os.path.join(DATA_DIR, "**", "*"), recursive=True):
+        base = os.path.basename(p)
+        if base.lower().endswith((".zip", ".csv")) and rx.search(base.upper()):
+            hits.append(p)
+    # prefer .CSV over .ZIP (already extracted), then most recently modified
+    hits.sort(key=lambda p: (p.lower().endswith(".zip"), -os.path.getmtime(p)))
+    return hits[0] if hits else None
+
+
+def _nic_read_csv_bytes(path):
+    """Return the CSV text from a user-placed NIC file (a .csv directly, or
+    the single .csv member of a .zip)."""
+    if path.lower().endswith(".zip"):
+        z = zipfile.ZipFile(path)
+        members = [n for n in z.namelist() if n.lower().endswith(".csv")]
+        if not members:
+            raise RuntimeError(
+                f"NIC zip {os.path.basename(path)} has no .csv member; "
+                f"members: {z.namelist()}")
+        with z.open(members[0]) as f:
+            return f.read().decode("latin-1")
+    with open(path, "rb") as f:
+        return f.read().decode("latin-1")
+
+
+def _nic_fetch(kind):
+    """Best-effort fetch of a NIC bulk ZIP. Expected to 403 from a server
+    IP (Akamai); returns the CSV text on the off chance it works, else
+    None so the caller falls back to the manual-file message."""
+    fname, _ = NIC_BULK[kind]
+    url = NIC_DATADOWNLOAD_URL.rsplit("/", 2)[0] + "/StaticData/DataDownload/" + fname
+    try:
+        r = requests.get(url, headers=_UA, timeout=(10, 120))
+    except requests.RequestException:
+        return None
+    if r.status_code != 200 or not r.content[:2] == b"PK":
+        return None
+    try:
+        z = zipfile.ZipFile(io.BytesIO(r.content))
+        members = [n for n in z.namelist() if n.lower().endswith(".csv")]
+        if not members:
+            return None
+        with z.open(members[0]) as f:
+            return f.read().decode("latin-1")
+    except zipfile.BadZipFile:
+        return None
+
+
+def _nic_load(kind):
+    """Load a NIC bulk table: user-placed file first (authoritative), else a
+    best-effort fetch, else fail loud with the manual path. Returns CSV text."""
+    placed = _nic_discover(kind)
+    if placed is not None:
+        return _nic_read_csv_bytes(placed)
+    text = _nic_fetch(kind)
+    if text is not None:
+        return text
+    fname, _ = NIC_BULK[kind]
+    raise RuntimeError(_nic_wall_message(kind, fname))
+
+
+def nic_relationships(refresh=False):
+    """NIC bulk **relationships** table — the parent/child ownership edges.
+
+    Returns a DataFrame keyed by the (ID_RSSD_PARENT, ID_RSSD_OFFSPRING)
+    edge with the timing/control columns (DT_START, DT_END, CTRL_IND,
+    PCT_EQUITY, ...). ID columns are Int64 and join-ready against
+    ``nic_attributes()`` on ID_RSSD. Requires a user-placed NIC bulk file
+    (see module note / the raised message) — the npw host is Akamai-walled.
+
+    `refresh` is accepted for signature symmetry; the file is read fresh
+    every call (it is small relative to the FFIEC SDF bundles).
+    """
+    _ensure_dir()
+    text = _nic_load("relationships")
+    df = pd.read_csv(io.StringIO(text), dtype=str, low_memory=False)
+    missing = [k for k in _NIC_REL_KEYS if k not in df.columns]
+    if missing:
+        raise RuntimeError(
+            f"NIC relationships file is missing key column(s) {missing}; "
+            f"got columns {list(df.columns)[:12]}... — schema may have "
+            "changed or the wrong file was placed.")
+    for c in (*_NIC_REL_KEYS, "DT_START", "DT_END", "CTRL_IND", "RELN_LVL"):
+        if c in df.columns:
+            df[c] = pd.to_numeric(df[c], errors="coerce").astype("Int64")
+    for c in ("PCT_EQUITY",):
+        if c in df.columns:
+            df[c] = pd.to_numeric(df[c], errors="coerce")
+    return df
+
+
+def nic_attributes(which="active", refresh=False):
+    """NIC bulk **attributes** table — entity descriptors keyed by ID_RSSD.
+
+    Args:
+        which: 'active' (default), 'closed', or 'branches' — selects the
+            CSV_ATTRIBUTES_{ACTIVE,CLOSED,BRANCHES} bundle.
+        refresh: accepted for symmetry (file is read fresh each call).
+
+    Returns a DataFrame keyed by ID_RSSD (Int64), join-ready against
+    ``nic_relationships()``. Requires a user-placed NIC bulk file.
+    """
+    kind = {"active": "attributes_active", "closed": "attributes_closed",
+            "branches": "attributes_branches"}.get(which)
+    if kind is None:
+        raise ValueError(
+            f"which must be 'active', 'closed', or 'branches', got {which!r}")
+    _ensure_dir()
+    text = _nic_load(kind)
+    df = pd.read_csv(io.StringIO(text), dtype=str, low_memory=False)
+    if _NIC_ATTR_KEY not in df.columns:
+        raise RuntimeError(
+            f"NIC attributes file is missing key column {_NIC_ATTR_KEY!r}; "
+            f"got columns {list(df.columns)[:12]}... — schema may have "
+            "changed or the wrong file was placed.")
+    df[_NIC_ATTR_KEY] = pd.to_numeric(
+        df[_NIC_ATTR_KEY], errors="coerce").astype("Int64")
+    return df
+
+
+def _bank_to_holder_nic(ids, asof):
+    """source='nic' path of bank_to_holder: walk controlling-parent edges of
+    the NIC relationships file up to the top holder, as of `asof`."""
+    pe = datetime.now() if asof is None else parse_quarter(asof)[2]
+    asof_int = int(pe.strftime("%Y%m%d"))
+    asof_str = pe.strftime("%Y-%m-%d")   # uniform with the FDIC-path format
+    rel = nic_relationships()
+    has_ctrl = "CTRL_IND" in rel.columns
+    has_dates = "DT_START" in rel.columns and "DT_END" in rel.columns
+    # offspring -> list of (parent, pct_equity) active & controlling at asof
+    edges = {}
+    for _, r in rel.iterrows():
+        par, off = r["ID_RSSD_PARENT"], r["ID_RSSD_OFFSPRING"]
+        if pd.isna(par) or pd.isna(off):
+            continue
+        # keep controlling edges only; a null CTRL_IND is conservatively
+        # treated as controlling (kept), not dropped
+        if has_ctrl and pd.notna(r["CTRL_IND"]) and int(r["CTRL_IND"]) != 1:
+            continue
+        if has_dates:
+            ds, de = r.get("DT_START"), r.get("DT_END")
+            if pd.notna(ds) and int(ds) > asof_int:
+                continue
+            # DT_END open-ended sentinel is 99991231; some older NIC
+            # snapshots use 0 — treat both as "not yet ended"
+            if pd.notna(de) and int(de) != 0 and int(de) < asof_int:
+                continue
+        pct = r.get("PCT_EQUITY")
+        edges.setdefault(int(off), []).append(
+            (int(par), float(pct) if pd.notna(pct) else -1.0))
+
+    def top_of(start):
+        cur, visited = start, {start}
+        while True:
+            parents = edges.get(cur)
+            if not parents:
+                return cur, (start != cur)
+            # pick the controlling parent with the largest recorded equity
+            # (sorted(), not list.sort(), so we don't mutate the shared
+            # edges[cur] list during the walk)
+            ordered = sorted(parents, key=lambda t: t[1], reverse=True)
+            nxt = next((p for p, _ in ordered if p not in visited), None)
+            if nxt is None:                # cycle guard
+                return cur, (start != cur)
+            visited.add(nxt)
+            cur = nxt
+
+    rows = []
+    for rid in ids:
+        if rid in edges:                   # rid appears as an offspring
+            holder, has_parent = top_of(rid)
+            rows.append({
+                "bank_rssd": rid, "holder_rssd": holder, "holder_name": pd.NA,
+                "is_independent": (not has_parent),
+                "asof": asof_str, "source": "nic",
+            })
+        else:
+            # rid never appears as an offspring -> no controlling parent on
+            # record at asof => it is its own top holder
+            rows.append({
+                "bank_rssd": rid, "holder_rssd": rid, "holder_name": pd.NA,
+                "is_independent": True, "asof": asof_str, "source": "nic",
+            })
+    return pd.DataFrame(rows)
+
+
 # ── multi-quarter panel ──
 
 def bank_panel(start_quarter, end_quarter, vars=None, source="fdic",
-               rssdids=None, certs=None, schedule="RC"):
+               rssdids=None, certs=None, schedule="RC", holder=False):
     """Stack quarterly bank data into a long panel.
 
     Args:
@@ -800,6 +1220,16 @@ def bank_panel(start_quarter, end_quarter, vars=None, source="fdic",
         rssdids: filter by IDRSSD (ffiec) — ignored for fdic (use certs).
         certs: filter by FDIC CERT (fdic source).
         schedule: SDF schedule for source='ffiec' (default 'RC').
+        holder: if True, append a ``holder_rssd`` (and, for fdic,
+            ``holder_name``) column giving each bank's top regulatory
+            holder — the documented correct rollup key (groupby it to
+            consolidate to the holding-company level). For source='fdic'
+            this is **point-in-time** (the RSSDHCR the FDIC reports for that
+            REPDTE, fetched in the same call — no extra requests). For
+            source='ffiec' the Call Report carries no holder field, so the
+            holder is mapped via bank_to_holder() at the **current**
+            snapshot (a documented asymmetry: ffiec holder is not as-of the
+            panel quarter). Aggregate with care across reorganizations.
 
     Returns: long DataFrame with a 'quarter' column. Note the per-source
     schema asymmetry: source='ffiec' frames carry a ``period_end``
@@ -816,9 +1246,20 @@ def bank_panel(start_quarter, end_quarter, vars=None, source="fdic",
             df = call_report((y, q), rssdids=rssdids, schedule=schedule)
             keycols = ["quarter", "period_end", "IDRSSD"]
         elif source == "fdic":
-            df = fdic_financials((y, q), certs=certs)
+            fields = None
+            if holder:
+                # extend the standard FDIC core set with the high-holder
+                # fields so the rollup key rides along point-in-time
+                fields = ["CERT", "REPDTE", "NAME", "STALP", "ASSET", "DEP",
+                          "LNLSNET", "EQ", "NETINC", "NIMY", "RBCT1J", "ROA",
+                          "ROE", "RSSDHCR", "NAMEHCR"]
+            df = fdic_financials((y, q), certs=certs, fields=fields)
             df.insert(0, "quarter", f"{y}Q{q}")
             keycols = ["quarter", "CERT", "REPDTE", "NAME"]
+            if holder:
+                df = df.rename(columns={"RSSDHCR": "holder_rssd",
+                                        "NAMEHCR": "holder_name"})
+                keycols += ["holder_rssd", "holder_name"]
         else:
             raise ValueError(f"source must be 'fdic' or 'ffiec', got {source!r}")
         if vars is not None:
@@ -834,4 +1275,54 @@ def bank_panel(start_quarter, end_quarter, vars=None, source="fdic",
                    [v for v in vars if v in df.columns]
             df = df[cols]
         frames.append(df)
-    return pd.concat(frames, ignore_index=True)
+    panel = pd.concat(frames, ignore_index=True)
+    if holder and source == "ffiec":
+        # IDRSSD is Int64 from the SDF parser, but coerce defensively so a
+        # stray non-numeric id can't raise an opaque int() error here
+        uniq = [int(x) for x in pd.to_numeric(panel["IDRSSD"],
+                                              errors="coerce").dropna().unique()]
+        hmap = bank_to_holder(uniq) if uniq else pd.DataFrame()
+        if not hmap.empty:
+            hmap = hmap[["bank_rssd", "holder_rssd", "holder_name"]]
+            panel = panel.merge(hmap, left_on="IDRSSD",
+                                right_on="bank_rssd", how="left").drop(
+                                columns="bank_rssd")
+            # bank_to_holder mixes int (resolved/independent) and pd.NA
+            # (RSSD absent from the FDIC directory) -> object column; cast
+            # to Int64 so resolved values compare/group correctly (an
+            # unresolvable bank stays <NA>, genuinely-unknown holder)
+            if "holder_rssd" in panel.columns:
+                panel["holder_rssd"] = pd.to_numeric(
+                    panel["holder_rssd"], errors="coerce").astype("Int64")
+    if holder and source == "fdic" and "holder_rssd" in panel.columns:
+        # FDIC reports RSSDHCR=NULL for banks with no higher holder. Left as
+        # NaN, those banks would (a) be silently dropped by a default
+        # groupby('holder_rssd') and (b) all collapse into one NaN group
+        # under dropna=False — both wrong. An independent bank IS its own
+        # top holder, so fill its holder_rssd with its own RSSD (resolved
+        # CERT->FED_RSSD; RSSD is time-invariant) and its holder_name with
+        # its own NAME, matching bank_to_holder's is_independent semantics.
+        hr = pd.to_numeric(panel["holder_rssd"], errors="coerce")
+        indep = hr.isna() | (hr == 0)
+        if indep.any() and "CERT" in panel.columns:
+            ucerts = [int(c) for c in panel.loc[indep, "CERT"].dropna().unique()]
+            inst = fdic_institutions(certs=ucerts, active_only=False) \
+                if ucerts else pd.DataFrame()
+            cert_to_rssd = {}
+            if not inst.empty and {"CERT", "FED_RSSD"}.issubset(inst.columns):
+                for _, r in inst.iterrows():
+                    ct, fr = r.get("CERT"), r.get("FED_RSSD")
+                    act = pd.to_numeric(r.get("ACTIVE"), errors="coerce") == 1
+                    if pd.notna(ct) and pd.notna(fr) and (
+                            int(ct) not in cert_to_rssd or act):
+                        cert_to_rssd[int(ct)] = int(fr)
+            own = panel.loc[indep, "CERT"].map(
+                lambda c: cert_to_rssd.get(int(c)) if pd.notna(c) else None)
+            hr = hr.astype("Float64")
+            hr[indep] = own.astype("Float64").values
+            panel["holder_rssd"] = hr
+            if "holder_name" in panel.columns and "NAME" in panel.columns:
+                panel.loc[indep, "holder_name"] = panel.loc[indep, "NAME"]
+        panel["holder_rssd"] = pd.to_numeric(
+            panel["holder_rssd"], errors="coerce").astype("Int64")
+    return panel

--- a/templates/skill_bodies/empirical/call-reports.md
+++ b/templates/skill_bodies/empirical/call-reports.md
@@ -130,10 +130,73 @@ literal-RCON `call_report` pulls (brittle, slower).
 ### The RSSD ↔ CERT crosswalk
 
 ```python
-fdic_institutions(certs=[628])            # -> NAME, FED_RSSD, ...
+fdic_institutions(certs=[628])            # -> NAME, FED_RSSD, RSSDHCR, ...
 fdic_institutions(rssdids=[852218])       # reverse lookup
-nic_link(852218)                          # RSSD -> CERT + identity
+nic_link(852218)                          # RSSD -> CERT + identity + holder
 ```
+
+### Rolling banks up to their holding company
+
+```python
+bank_to_holder(852218)                    # JPMorgan bank RSSD -> 1039502 (the BHC)
+bank_to_holder([852218, 480228])          # vectorized; one row per input
+bank_to_holder(852218, asof='2020Q4')     # point-in-time top holder
+panel = bank_panel('2021Q1', '2023Q4',    # panel WITH the rollup key attached
+        vars=['ASSET','DEP'], source='fdic', holder=True)
+panel.groupby(['quarter','holder_rssd'])['ASSET'].sum()   # consolidate to holder
+```
+
+`bank_to_holder` is the **correct, no-name-match** way to consolidate
+bank-level Call Reports to the holding-company level. It reads the
+**Regulatory High Holder** (`RSSDHCR`/`NAMEHCR`) that the FDIC carries
+(sourced from NIC) — no API key, **not** behind the NIC Akamai wall.
+`asof=None` is the current snapshot (`/institutions`); an `asof` quarter
+spec is point-in-time (`/financials`, which carries `RSSDHCR` per
+`REPDTE`). Returns one row per input RSSD with `holder_rssd`,
+`holder_name`, `is_independent` (a bank that is its own top holder), and
+`<NA>` holder fields for an unresolved id (not FDIC-insured / absent that
+quarter). The verifiable hand-check: bank RSSD `852218` → holder RSSD
+`1039502`, which is exactly the BHC RSSD the `y9c` example pulls.
+
+`bank_panel(..., holder=True)` attaches `holder_rssd`/`holder_name` so you
+can `groupby` the holder. For `source='fdic'` the holder is point-in-time
+(rides along in the same call); for `source='ffiec'` the Call Report has
+no holder field, so it is mapped at the **current** snapshot (a documented
+asymmetry — not as-of the panel quarter).
+
+**FBO caveat.** `RSSDHCR` is the top of the *domestic* regulatory chain.
+For US subsidiaries of foreign banking organizations it stops at the US
+intermediate holding company, **not** the foreign ultimate parent (e.g.
+Santander Bank NA → Santander Holdings USA, not Banco Santander S.A.).
+This is a NIC definition, not a retrieval gap — use `nic_relationships()`
+to walk above the US IHC when the foreign parent is needed.
+
+### Full ownership tree (NIC bulk — manual download)
+
+For the *multi-level* tree (intermediate parents, equity percentages,
+historical as-of edges) — beyond the single top-holder hop FDIC gives —
+use the NIC bulk relationships/attributes tables:
+
+```python
+rel  = nic_relationships()                # parent/offspring edges, CTRL_IND, PCT_EQUITY
+attr = nic_attributes(which='active')     # entity descriptors, keyed ID_RSSD
+rel.merge(attr, left_on='ID_RSSD_OFFSPRING', right_on='ID_RSSD')   # join-ready
+bank_to_holder(852218, source='nic', asof='2020Q4')   # walk controlling-parent edges
+```
+
+The NIC Financial Data Download host is behind **Akamai bot protection**
+that 403s server/datacenter IPs on every path (same wall as `y9c`
+2021Q2+). These helpers attempt a best-effort fetch and otherwise raise an
+instructive `RuntimeError`: download the CSV bundle in a browser and drop
+the file (e.g. `CSV_RELATIONSHIPS.ZIP` or its extracted `.CSV`) anywhere
+under `data/call_reports/` — the filename just has to contain the table
+name. `source='nic'` walks controlling parent edges (`CTRL_IND=1`, or
+unrecorded — null control status is conservatively treated as controlling)
+active at `asof` up to the top holder; when a node has several controlling
+parents it follows the one with the largest recorded `PCT_EQUITY` (a
+documented heuristic — note the ambiguity if you rely on it). **For the
+common bank→top-holder rollup you do not need this file —
+`bank_to_holder()` (FDIC) is the no-download path.**
 
 ## The ID linking nightmare
 
@@ -152,10 +215,10 @@ Rules of thumb:
 - **Bank-level** analysis → key on RSSD (`IDRSSD`). **Holding-company**
   analysis → key on the BHC's `RSSD9001` from Y-9C.
 - A BHC's RSSD is **not** its lead bank's RSSD. To roll banks up to their
-  holder, do **not** name-match — use the NIC bulk relationships/attributes
-  CSVs (`CSV_RELATIONSHIPS`, `CSV_ATTRIBUTES`) from the NIC Financial Data
-  Download, joined on `ID_RSSD`. `nic_link`'s docstring documents this; it
-  itself only does the reliable RSSD↔CERT lookup via the FDIC API.
+  holder, do **not** name-match — use `bank_to_holder()` (the no-key FDIC
+  Regulatory-High-Holder path), or `nic_relationships()`/`nic_attributes()`
+  (joined on `ID_RSSD`) when you need the full multi-level tree. `nic_link`
+  does the reliable RSSD↔CERT lookup and now also returns `RSSDHCR`.
 - `RSSD9001` (reporter) vs `RSSD9999` (as-of date) — `9001` is the entity.
 
 ## Standard operations
@@ -171,8 +234,11 @@ Rules of thumb:
 - **Intermediary asset pricing (holding-company leverage):** `y9c` BHCK
   equity / assets at the consolidated BHC level; bank-level Call Reports
   miss the holding-company leverage that the He–Kelly–Manela channel uses.
-- **Merge banks to holders:** FDIC `FED_RSSD` → NIC relationships table →
-  top-holder RSSD; aggregate Call Report items by holder.
+- **Merge banks to holders:** `bank_panel(start, end, source='fdic',
+  holder=True)` then `groupby(['quarter','holder_rssd']).sum()` — the
+  point-in-time FDIC high-holder rollup, no manual download. Use
+  `nic_relationships()` only when you need intermediate-tier consolidation
+  or ownership percentages.
 
 ## Rules
 
@@ -187,8 +253,9 @@ Rules of thumb:
   a stated NIC bot-protection limit, not a helper bug; report it in the
   data appendix the way the `hrs-scf` registration step is reported.
 - **Never join on a guessed ID.** RSSD↔CERT is a lookup
-  (`fdic_institutions`); bank↔holder is the NIC relationships table. No
-  name matching for entity resolution.
+  (`fdic_institutions`); bank↔holder is `bank_to_holder()` (FDIC
+  high-holder) or the NIC relationships table. No name matching for entity
+  resolution.
 - **Report the source per series.** FFIEC RCON, Chicago-Fed/NIC BHCK, and
   FDIC standardized fields are *not* interchangeable line items; state
   which produced each number.

--- a/test_scripts/test_call_reports.py
+++ b/test_scripts/test_call_reports.py
@@ -1,9 +1,18 @@
-"""Test call-reports skill (issue #7) — FFIEC CDR + FR Y-9C + FDIC API.
+"""Test call-reports skill (issues #7, #33) — FFIEC CDR + FR Y-9C + FDIC API.
 
 Acceptance (issue #7):
   * Pull one quarter's Call Report, extract RCON-coded variables
     (RCON2170 total assets), and count banks.
   * Exercise the RSSD <-> CERT linking crosswalk.
+
+Acceptance (issue #33 — bank -> holding-company rollup):
+  * bank_to_holder() maps a known bank RSSD to its known top-holder RSSD,
+    hand-checked (852218 -> 1039502 JPMorgan; 480228 -> 1073757 BofA).
+  * bank_panel(holder=True) attaches the rollup key point-in-time.
+  * nic_relationships()/nic_attributes() raise the documented Akamai-wall
+    RuntimeError when no bulk file is placed (HARD — the wall is a stated
+    limit, like the Y-9C 2021Q2+ manual step), and the source='nic' walk
+    is exercised only when a user file is present (documented SKIP).
 
 Test policy mirrors the codebase convention (hrs-scf): the reliable,
 no-key paths (FDIC API; Chicago Fed pre-2021Q1 BHCF) are HARD assertions;
@@ -19,11 +28,15 @@ import sys
 
 from utils.call_reports_utils import (
     call_report, y9c, bank_panel, fdic_financials, fdic_institutions,
-    nic_link, parse_quarter, FFIEC_FORM_BRITTLENESS,
+    nic_link, bank_to_holder, nic_relationships, nic_attributes,
+    parse_quarter, FFIEC_FORM_BRITTLENESS,
 )
 
 JPM_BANK_RSSD = 852218   # JPMorgan Chase Bank, N.A. (a bank)
 JPM_BANK_CERT = 628
+JPM_HOLDER_RSSD = 1039502  # JPMorgan Chase & Co. (the top BHC) — the y9c example
+BOFA_BANK_RSSD = 480228  # Bank of America, N.A.
+BOFA_HOLDER_RSSD = 1073757  # Bank of America Corp (top BHC)
 
 # === Test 1: quarter parsing ===
 print("=== Test 1: parse_quarter ===")
@@ -69,6 +82,102 @@ try:
 except RuntimeError as e:
     assert "cutoff" in str(e) and "NIC" in str(e), f"wrong error: {e}"
     print("  2023Q4 (post-2021Q1): documented manual-download RuntimeError OK")
+
+# === Test 4b: bank_to_holder — issue #33 ACCEPTANCE (HARD, no key) ===
+# Placed before the brittle FFIEC path so it runs regardless of FFIEC
+# reachability (Test 5 may sys.exit early when the bulk form is down).
+print("\n=== Test 4b: bank_to_holder — bank RSSD -> top holder RSSD ===")
+h = bank_to_holder([JPM_BANK_RSSD, BOFA_BANK_RSSD]).set_index("bank_rssd")
+assert int(h.loc[JPM_BANK_RSSD, "holder_rssd"]) == JPM_HOLDER_RSSD, \
+    f"JPM bank {JPM_BANK_RSSD} should roll up to BHC {JPM_HOLDER_RSSD}"
+assert int(h.loc[BOFA_BANK_RSSD, "holder_rssd"]) == BOFA_HOLDER_RSSD, \
+    f"BofA bank {BOFA_BANK_RSSD} should roll up to BHC {BOFA_HOLDER_RSSD}"
+assert not bool(h.loc[JPM_BANK_RSSD, "is_independent"])
+# the JPM holder RSSD is exactly the BHC the y9c example pulls
+assert JPM_HOLDER_RSSD == 1039502
+# scalar input -> one row
+assert len(bank_to_holder(JPM_BANK_RSSD)) == 1
+# point-in-time path (financials RSSDHCR per REPDTE)
+hp = bank_to_holder(JPM_BANK_RSSD, asof="2020Q4")
+assert int(hp.iloc[0]["holder_rssd"]) == JPM_HOLDER_RSSD, "point-in-time rollup"
+assert hp.iloc[0]["asof"] == "2020-12-31"
+# unresolved id (not FDIC-insured) -> total mapping, NA holder, no raise
+hu = bank_to_holder([999999999])
+assert len(hu) == 1 and pd.isna(hu.iloc[0]["holder_rssd"])
+# an independent bank (its own top holder) -> is_independent True.
+# RSSD 37 = Bank of Hancock County, a known independent bank (RSSDHCR=<NA>);
+# hardcoded so the assertion always runs (no full-table pull, no if-guard).
+_d = bank_to_holder(37)
+assert bool(_d.iloc[0]["is_independent"]) and \
+    int(_d.iloc[0]["holder_rssd"]) == 37, "independent-bank rollup"
+print(f"  {JPM_BANK_RSSD} -> {JPM_HOLDER_RSSD} (JPMorgan & Co), "
+      f"{BOFA_BANK_RSSD} -> {BOFA_HOLDER_RSSD} (BofA Corp); "
+      "scalar/vector/asof/unresolved/independent all OK")
+
+# === Test 4c: bank_panel(holder=True) attaches point-in-time rollup key ===
+print("\n=== Test 4c: bank_panel(holder=True, source='fdic') ===")
+# include an independent bank (no holding company) to verify it is NOT
+# left as NaN holder (which a default groupby would silently drop, and
+# dropna=False would wrongly lump all independents into one group)
+_ind = fdic_institutions(rssdids=[37])  # Bank of Hancock County (own holder)
+_ind_cert = int(_ind.iloc[0]["CERT"]) if len(_ind) else None
+_certs = [JPM_BANK_CERT, 3510] + ([_ind_cert] if _ind_cert else [])
+hp_panel = bank_panel("2023Q3", "2023Q4", vars=["ASSET"], source="fdic",
+                      certs=_certs, holder=True)
+assert {"holder_rssd", "holder_name"}.issubset(hp_panel.columns), \
+    "holder=True must attach holder_rssd/holder_name"
+assert str(hp_panel["holder_rssd"].dtype) == "Int64", "holder_rssd must be Int64"
+_jpm = hp_panel[hp_panel["CERT"] == JPM_BANK_CERT]
+assert (_jpm["holder_rssd"] == JPM_HOLDER_RSSD).all(), \
+    "JPM rows must carry the BHC holder RSSD each quarter"
+if _ind_cert:
+    _indrows = hp_panel[hp_panel["CERT"] == _ind_cert]
+    assert _indrows["holder_rssd"].notna().all() and \
+        (_indrows["holder_rssd"] == 37).all(), \
+        "independent bank must roll up to its OWN RSSD (37), not NaN"
+# the rollup is groupby-able to the holding-company level; the independent
+# bank survives as its own group (not silently dropped)
+agg = hp_panel.groupby(["quarter", "holder_rssd"])["ASSET"].sum()
+assert len(agg) > 0
+if _ind_cert:
+    assert 37 in agg.index.get_level_values("holder_rssd"), \
+        "independent bank silently dropped by groupby('holder_rssd')"
+print(f"  panel carries Int64 holder_rssd (incl. independent banks); "
+      f"groupby holder -> {len(agg)} holder-quarters")
+
+# === Test 4d: NIC bulk wall — documented manual-download (issue #33) ===
+print("\n=== Test 4d: nic_relationships/nic_attributes Akamai-wall behavior ===")
+import os as _os
+from utils.call_reports_utils import DATA_DIR as _DD, _nic_discover
+_have_rel = _nic_discover("relationships") is not None
+if _have_rel:
+    rel = nic_relationships()
+    assert "ID_RSSD_PARENT" in rel.columns and "ID_RSSD_OFFSPRING" in rel.columns
+    assert str(rel["ID_RSSD_OFFSPRING"].dtype) == "Int64"
+    nh = bank_to_holder(JPM_BANK_RSSD, source="nic", asof="2020Q4")
+    assert int(nh.iloc[0]["bank_rssd"]) == JPM_BANK_RSSD
+    # asof format must match the FDIC path (YYYY-MM-DD), not raw YYYYMMDD
+    assert nh.iloc[0]["asof"] == "2020-12-31", \
+        f"NIC asof should be ISO YYYY-MM-DD, got {nh.iloc[0]['asof']!r}"
+    print(f"  user-placed NIC file found: {len(rel):,} relationship edges; "
+          "source='nic' walk + asof format OK")
+else:
+    for fn in (lambda: nic_relationships(),
+               lambda: nic_attributes(which="active")):
+        try:
+            fn()
+            raise AssertionError("NIC helper should raise when no file placed")
+        except RuntimeError as e:
+            assert "Akamai" in str(e) and "browser" in str(e), \
+                f"NIC wall error not instructive: {e}"
+    # bad 'which' is a hard ValueError regardless of file presence
+    try:
+        nic_attributes(which="bogus")
+        raise AssertionError("bad which should raise ValueError")
+    except ValueError:
+        pass
+    print("  no user file placed: documented Akamai-wall RuntimeError OK "
+          "(source='nic' walk SKIPPED — drop a NIC bulk file to exercise it)")
 
 # === Test 5: FFIEC CDR literal RCON — ACCEPTANCE (HARD if reachable) ===
 print("\n=== Test 5: call_report('2023Q4','RC') — RCON2170, count banks ===")


### PR DESCRIPTION
Closes #33.

## Summary
The issue scoped a NIC bulk relationships/attributes downloader to roll bank-level Call Reports up to the holding company. Investigation confirmed the **NIC Financial Data Download host is Akamai-walled** (403s every datacenter IP, every path — same wall as `y9c` 2021Q2+). But the **FDIC API already exposes each bank's Regulatory High Holder** (`RSSDHCR`/`NAMEHCR`, sourced from NIC), no key, not walled — so the core rollup needs **zero manual download**. This supersedes the issue's NIC-bulk assumption with an FDIC-primary design (NIC bulk remains the optional richer-tree path).

Verified hand-checks: `852218 → 1039502` (JPMorgan, matching the `y9c` example's BHC), `480228 → 1073757` (BofA), `37 → 37` (independent).

## What's implemented
- **`bank_to_holder(rssdids, asof=None, source='fdic')`** — bank RSSD → top regulatory-high-holder RSSD. Current snapshot (`/institutions`) or point-in-time (`/financials`, RSSDHCR per `REPDTE`). Scalar/vectorized, multi-CERT-history aware, independent banks → themselves, unresolved → `<NA>`, NA-input guard, uniform `YYYY-MM-DD` `asof`. Documents the FBO/US-IHC limitation.
- **`nic_relationships()` / `nic_attributes(which=)`** — Int64 join-ready tables; best-effort fetch + recursive user-placed-file fallback with a loud Akamai-wall message; schema-drift validation. `source='nic'` walks controlling-parent edges (CTRL_IND incl. null; `DT_END` 0/99991231 open sentinels; cycle guard; `PCT_EQUITY` tie-break).
- **`bank_panel(holder=True)`** — point-in-time holder key for `fdic` (independent banks filled to own RSSD, Int64); current-snapshot for `ffiec` (Int64, documented asymmetry).
- `fdic_institutions` now returns/Int64-coerces `RSSDHCR`/`NAMEHCR`; fixed `fdic_financials` silently NaN-ing the text `NAMEHCR` field. `nic_link` "documented but not implemented" caveat removed.

## Acceptance (issue #33)
- ✅ `nic_relationships()`/`nic_attributes()` return Int64-keyed tables (live or user-placed; loud instructive error otherwise)
- ✅ `bank_to_holder()` maps a known bank RSSD to its known top-holder RSSD (hand-checked)
- ✅ Skill body + docstrings updated; `nic_link` caveat removed
- ✅ Reviewed per CLAUDE.md — clean over 5 Sonnet audit rounds (R1:6 issues → R2:1 → R3:clean → R4:5 fresh deep audit → R5:clean)

## Tests
`test_call_reports.py` gains Tests 4b/4c/4d (placed before the brittle FFIEC path so they always run). Full suite passes against the live FDIC API.

No `setup.sh`/manifest change needed — all touched paths are existing deployed files; `test_scripts/` is stripped on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)